### PR TITLE
add service layer to accounts app

### DIFF
--- a/backend/apps/accounts/schema.py
+++ b/backend/apps/accounts/schema.py
@@ -1,7 +1,5 @@
 import typing as t
 
-from piccolo.apps.user.tables import BaseUser
-from piccolo_api.crud.serializers import create_pydantic_model
 from pydantic import BaseModel
 
 
@@ -16,24 +14,13 @@ class TokenData(BaseModel):
 
 
 # user schema
-UserModelInBase: t.Any = create_pydantic_model(
-    table=BaseUser,
-    exclude_columns=(
-        BaseUser.active,
-        BaseUser.admin,
-        BaseUser.superuser,
-    ),
-    model_name="UserModelIn",
-)
-UserModelOutBase: t.Any = create_pydantic_model(
-    table=BaseUser,
-    include_default_columns=True,
-    model_name="UserModelOut",
-)
+class UserModelIn(BaseModel):
+    username: str
+    email: str
+    password: str
 
 
-# keep Pylance happy
-class UserModelIn(UserModelInBase): ...
-
-
-class UserModelOut(UserModelOutBase): ...
+class UserModelOut(BaseModel):
+    id: int
+    username: str
+    email: str

--- a/backend/apps/accounts/services.py
+++ b/backend/apps/accounts/services.py
@@ -1,0 +1,59 @@
+from typing import Any
+
+from fastapi.security import OAuth2PasswordRequestForm
+from piccolo.apps.user.tables import BaseUser
+
+from apps.accounts.schema import UserModelIn, UserModelOut
+from apps.tasks.tables import Task
+
+
+class UserService:
+    """
+    User service class
+    """
+
+    async def user_login(
+        self,
+        form_data: OAuth2PasswordRequestForm,
+    ) -> dict[str, Any] | None:
+        user = await BaseUser.login(
+            username=form_data.username, password=form_data.password
+        )
+        return (
+            await BaseUser.select()
+            .where(BaseUser._meta.primary_key == user)
+            .first()
+        )
+
+    async def user_register(self, user: UserModelIn) -> UserModelOut:
+        payload = user.model_dump()
+        if await BaseUser.exists().where(
+            BaseUser.email == user.email
+        ) or await BaseUser.exists().where(BaseUser.username == user.username):
+            raise Exception(
+                "User with that email or username already exists.",
+            )
+        result = BaseUser(**payload)
+        await result.save()
+        return UserModelOut(**result.to_dict())
+
+    async def delete_user(
+        self,
+        current_user: UserModelOut,
+    ) -> None:
+        await BaseUser.delete().where(
+            BaseUser._meta.primary_key == current_user.id
+        )
+
+    async def user_tasks_list(
+        self,
+        current_user: UserModelOut,
+    ) -> list:
+        return (
+            await Task.select()
+            .where(Task.task_user == current_user.id)
+            .order_by(Task._meta.primary_key, ascending=False)
+        )
+
+
+user_service = UserService()

--- a/backend/apps/accounts/utils.py
+++ b/backend/apps/accounts/utils.py
@@ -1,0 +1,58 @@
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import jwt
+from fastapi import Depends, HTTPException, status
+from jwt.exceptions import InvalidTokenError
+from piccolo.apps.user.tables import BaseUser
+
+from apps.accounts.auth import OAuth2PasswordBearerCookie
+from apps.accounts.schema import TokenData
+from config.base import settings
+
+oauth2_scheme = OAuth2PasswordBearerCookie(token_url="accounts/login")
+
+
+async def create_access_token(
+    data: dict,
+    expires_delta: Optional[timedelta] = None,
+) -> str:
+    to_encode = data.copy()
+    if expires_delta:
+        expire = datetime.now(timezone.utc) + expires_delta
+    else:
+        expire = datetime.now(timezone.utc) + timedelta(minutes=15)
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(
+        to_encode, settings.secret_key, algorithm=settings.algorithm
+    )
+    return encoded_jwt
+
+
+async def get_current_user(
+    token: str = Depends(oauth2_scheme),
+) -> BaseUser:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(
+            token, settings.secret_key, algorithms=[settings.algorithm]
+        )
+        username: str = payload.get("sub")
+        if username is None:
+            raise credentials_exception
+        token_data = TokenData(username=username)
+    except InvalidTokenError:
+        raise credentials_exception
+    user = (
+        await BaseUser.objects()
+        .where(BaseUser.username == token_data.username)
+        .first()
+        .run()
+    )
+    if user is None:
+        raise credentials_exception
+    return user

--- a/backend/apps/tasks/endpoints.py
+++ b/backend/apps/tasks/endpoints.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends
 from piccolo_api.crud.endpoints import PiccoloCRUD
 from piccolo_api.fastapi.endpoints import FastAPIKwargs, FastAPIWrapper
 
-from apps.accounts.endpoints import oauth2_scheme
+from apps.accounts.utils import oauth2_scheme
 from apps.tasks.tables import Task
 
 tasks_router = APIRouter()

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,7 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from piccolo.engine import engine_finder
 from starlette.routing import Mount
 
-from apps.accounts.endpoints import router
+from apps.accounts.endpoints import auth_router
 from apps.admin.config import ADMIN
 from apps.tasks.endpoints import tasks_router
 from utils.reset_password.endpoints import forgot_password, reset_password
@@ -57,7 +57,7 @@ def index():
     return {"message": "Welcome to Piccolo Vue starter"}
 
 
-app.include_router(router)
+app.include_router(auth_router)
 app.include_router(tasks_router)
 
 


### PR DESCRIPTION
In this repo I use Piccolo FastAPIWrapper to show how easy it is to get crud operation, filtering, pagination with Piccolo. Updated the accounts app to use the service layer and that pattern should be used if we are not using FastAPIWrapper or PiccoloCRUD. The basic structure is this
```bash
tree
.
├── __init__.py
├── endpoints.py # app endpoints (routers)
├── schema.py # DTO's (Pydantic schema models)
├── services.py # service layer (app logic)
└── utils.py # utility functions
```
